### PR TITLE
Docs: Add gameplay guide and WeChat publishing steps

### DIFF
--- a/how_to_play_spirit_bloom_garden.txt
+++ b/how_to_play_spirit_bloom_garden.txt
@@ -1,0 +1,46 @@
+**How to Play: Spirit Bloom Garden**
+
+Welcome, Gardener! Get ready to cultivate a magical garden full of wondrous Spirit Blooms. Merge flowers, gather energy, and protect your peaceful space from mischievous Shadow Sprites!
+
+**1. Your Magical Garden**
+
+*   **The Goal:** Your aim is to grow beautiful and powerful Spirit Flowers by merging them. Higher-tier flowers generate more Spirit Energy, allowing you to expand your garden's wonders (future feature!). For now, enjoy the process of discovery and keep your garden clear of sprites!
+*   **The Game Board:** Your garden is laid out in plots. This is where your Spirit Flowers will grow and where Shadow Sprites might appear.
+
+**2. Core Actions: Tending Your Garden**
+
+*   **Tapping a Plot:**
+    *   **Selecting a Flower:** If you tap a plot containing a Spirit Flower, you'll select it. Selected flowers are usually highlighted with a special border.
+    *   **Interacting with Sprites:** If you tap a plot where a Shadow Sprite is lurking, you'll damage the sprite! Keep tapping to dispel it.
+*   **Merging Flowers:** This is the heart of your garden's growth!
+    1.  **Select First Flower:** Tap on a flower to select it.
+    2.  **Select Second Flower:** Tap on another flower of the *same type and same tier*.
+    3.  **Magic!** If the flowers are compatible, they will merge into a single, more powerful flower of the next tier! The new flower will appear on the plot you tapped for the second flower.
+    *   *Example:* Tapping a Tier 1 Water Flower, then tapping another Tier 1 Water Flower, will create a Tier 2 Water Flower.
+    *   *No Match?* If you try to merge incompatible flowers (different types or tiers), the merge won't happen. Your first flower will usually remain selected, or your selection might reset.
+*   **Deselecting a Flower:** If you've selected a flower but want to choose a different one, simply tap the selected flower again, or tap an empty plot.
+
+**3. Understanding Your Spirit Flowers**
+
+*   **Elements & Tiers:** Your flowers have different elemental types (like Water, Fire, Earth) and come in different tiers (Tier 1, Tier 2, etc.). You'll see "T1", "T2" on your flowers.
+*   **Spirit Energy:** Each flower automatically generates Spirit Energy over time. This energy is collected automatically for now. You can see your total Spirit Energy at the top/bottom of the screen. Higher-tier flowers generate much more energy!
+
+**4. Dealing with Shadow Sprites**
+
+*   **Pesky Intruders:** From time to time, mischievous Shadow Sprites may appear in your garden! They will try to disrupt your flowers.
+*   **Dispelling Sprites:**
+    *   When you see a sprite, tap on it directly!
+    *   Each tap reduces the sprite's health.
+    *   Keep tapping until its health runs out, and it will be dispelled from your garden.
+    *   Sprites may prevent flowers on their plot from generating energy while they are active.
+
+**5. The Game Interface**
+
+*   **Game Board:** The main area with your flower plots.
+*   **Energy Display:** Shows your current total Spirit Energy.
+
+**Tips for a Blooming Garden:**
+
+*   Always try to merge flowers to discover new, higher-tier blooms.
+*   Keep an eye out for Shadow Sprites and dispel them quickly to protect your energy generation!
+*   Have fun experimenting and watching your magical garden grow!

--- a/wechat_minigame_publishing_steps.txt
+++ b/wechat_minigame_publishing_steps.txt
@@ -1,0 +1,49 @@
+**General Steps to Publish a WeChat Mini-Game**
+
+Publishing a WeChat Mini-Game involves several key stages, from setting up your developer account to submitting your game for review and finally releasing it to the public. Always refer to the official WeChat Developer documentation for the most up-to-date and detailed instructions.
+
+1.  **Developer Account Registration and Setup:**
+    *   **Register a WeChat Official Account:** You'll typically need a registered WeChat Official Account (Service Account or, in some cases, Subscription Account, though Service Accounts often have more APIs available). This might involve business verification depending on your location and account type.
+    *   **Activate Mini-Program/Mini-Game Services:** Within your Official Account admin panel, you'll need to activate the Mini-Program or Mini-Game development services.
+    *   **Developer ID (AppID):** Once activated, you will receive an AppID for your Mini-Game, which is crucial for development and publishing.
+    *   **Developer Tools:** Download and install the WeChat Developer Tools. This IDE is essential for developing, debugging, previewing, and uploading your Mini-Game.
+
+2.  **Development and Preparation:**
+    *   **Complete Game Development:** Ensure your game is fully developed, tested, and adheres to WeChat's Mini-Game development guidelines and policies (e.g., content restrictions, performance standards, user privacy).
+    *   **Asset Optimization:** Optimize all game assets (images, audio) for fast loading times and smooth performance on various devices.
+    *   **Testing:** Thoroughly test your game on multiple devices and network conditions. Use the WeChat Developer Tools for debugging and performance analysis.
+    *   **Game Information:** Prepare all necessary game information, including:
+        *   Game Name (must be unique and appropriate)
+        *   Game Description
+        *   Game Icon (specific dimensions and format)
+        *   Screenshots and/or Promo Video
+        *   Category/Genre
+        *   Keywords
+        *   Privacy Policy (if applicable)
+        *   Any required licenses or certifications (e.g., for games with paid content or specific themes in certain regions).
+
+3.  **Submission for Review:**
+    *   **Project Configuration:** Configure your `project.config.json` file with your AppID and other settings.
+    *   **Upload Version:** Using the WeChat Developer Tools, upload a version of your game code to the WeChat developer backend.
+    *   **Fill in Submission Form:** In the WeChat Mini-Program admin panel, navigate to the version management section. Select the uploaded version and fill out the submission form with all the prepared game information.
+    *   **Content Compliance:** Ensure your game complies with WeChat's platform policies, including content guidelines, user data privacy, and monetization rules. Be particularly mindful of rules regarding sharing, incentives, and virtual payments.
+    *   **Submit for Review:** Once all information is complete and verified, submit the game for review by the WeChat team.
+
+4.  **Review Process:**
+    *   **Waiting Period:** The review process can take anywhere from a few hours to several days, depending on various factors.
+    *   **Feedback/Rejection:** If your game is rejected, WeChat will provide reasons. You'll need to address these issues and resubmit. Common reasons for rejection include policy violations, bugs, performance issues, or incomplete information.
+    *   **Approval:** If your game passes the review, you'll be notified.
+
+5.  **Release and Post-Launch:**
+    *   **Publish:** After approval, you can choose to publish your game immediately or schedule a release time.
+    *   **Phased Release (if available):** Some platforms offer phased releases to a percentage of users, allowing you to monitor stability before a full rollout. Check if WeChat offers such options.
+    *   **Monitoring:** After launch, monitor your game's performance, user feedback, and analytics through the WeChat developer backend.
+    *   **Updates:** You can submit updates to your game to fix bugs, add new features, or improve performance. Each update will typically go through a similar review process.
+    *   **Compliance:** Continuously ensure your game remains compliant with any changes to WeChat's policies.
+
+**Key Considerations:**
+
+*   **Localization:** If targeting users in different language regions, consider localizing your game content and store listing.
+*   **Monetization:** If your game includes monetization (e.g., ads, in-app purchases), ensure it complies with WeChat's specific monetization policies. WeChat has its own ad platform and payment systems.
+*   **User Privacy:** Be transparent about data collection and usage, and comply with all relevant privacy regulations.
+*   **Official Documentation:** The WeChat Developer documentation is your primary resource. Policies and procedures can change, so always refer to it.


### PR DESCRIPTION
This commit adds two documentation files:

1.  `how_to_play_spirit_bloom_garden.txt`: A user-friendly guide explaining how to play the "Spirit Bloom Garden" game based on its current features (merging, energy, sprites).

2.  `wechat_minigame_publishing_steps.txt`: An outline of the general steps involved in publishing a WeChat Mini-Game, from developer account setup to review and release.

These documents provide valuable information for players and developers associated with the project.